### PR TITLE
PXEmngr vhost: drop NameVirtualHost

### DIFF
--- a/ansible/pxemngr-apache.conf
+++ b/ansible/pxemngr-apache.conf
@@ -1,4 +1,3 @@
-NameVirtualHost *:83
 Listen 83
 
 <VirtualHost *:83>

--- a/ansible/pxemngr-httpd.conf
+++ b/ansible/pxemngr-httpd.conf
@@ -1,4 +1,3 @@
-NameVirtualHost *:83
 Listen 83
 
 <VirtualHost *:83>


### PR DESCRIPTION
NameVirtualHost has no effect and will be removed in the next Apache2
release.

Source: AH00548
